### PR TITLE
Update coulomb_interrupt.ino

### DIFF
--- a/Software/Arduino/coulomb_interrupt/coulomb_interrupt.ino
+++ b/Software/Arduino/coulomb_interrupt/coulomb_interrupt.ino
@@ -163,7 +163,7 @@ void setup()
   // On 328 Arduinos, you may also use D2 (INT0), change '1' to '0'. 
 
   isrflag = false;
-  attachInterrupt(1,myISR,FALLING);
+  attachInterrupt(digitalPinToInterrupt(INT),myISR,FALLING);
 }
 
 void loop()


### PR DESCRIPTION
Actually using the INT pin variable, so that people using any pin other than D3 (or any other board than the 328 Arduinos) can specify their INT pin.